### PR TITLE
Add helper to query visible Lidar actors

### DIFF
--- a/Source/PointCloudExport/ExportVisibleLidarPointsLOD.cpp
+++ b/Source/PointCloudExport/ExportVisibleLidarPointsLOD.cpp
@@ -527,7 +527,9 @@ TArray<ALidarPointCloudActor*> UExportVisibleLidarPointsLOD::GetVisibleLidarActo
             continue;
         }
 
-        FBoxSphereBounds Bounds = Comp->CalcBounds(Comp->GetComponentTransform());
+        // Use the actor's component bounds instead of the private CalcBounds API
+        FBox BoundsBox = Actor->GetComponentsBoundingBox(true);
+        FBoxSphereBounds Bounds(BoundsBox);
         if (WorldFrustum.IntersectBox(Bounds.Origin, Bounds.BoxExtent))
         {
             Result.Add(Actor);

--- a/Source/PointCloudExport/ExportVisibleLidarPointsLOD.h
+++ b/Source/PointCloudExport/ExportVisibleLidarPointsLOD.h
@@ -38,10 +38,10 @@ public:
      * @return                    成功可否
      */
     UFUNCTION(BlueprintCallable, Category = "Lidar|Export")
-    static bool ExportVisiblePointsLOD(
-        const TArray<ALidarPointCloudActor*>& PointCloudActors,
-        UCameraComponent*      Camera,
-        const FString& AbsoluteFilePath,
+      static bool ExportVisiblePointsLOD(
+          const TArray<ALidarPointCloudActor*>& PointCloudActors,
+          UCameraComponent*      Camera,
+          const FString& AbsoluteFilePath,
         float                  FrustumFar = 10000.f,
         float                  NearFullResRadius = 5000.f,
         float                  MidSkipRadius = 20000.f,
@@ -49,7 +49,20 @@ public:
         int32                  SkipFactorMid = 2,
         int32                  SkipFactorFar = 10,
         bool                   bWorldSpace = true,
-        bool                   bExportTexture = false,
-        float                  MergeDistance = 0.f
+          bool                   bExportTexture = false,
+          float                  MergeDistance = 0.f
+      );
+
+    /**
+     * カメラの視錐台に入っている LidarPointCloudActor を取得
+     *
+     * @param Camera     チェックするカメラコンポーネント
+     * @param FrustumFar 視錐台の Far 値 [cm]
+     * @return           視錐台に入るアクター配列
+     */
+    UFUNCTION(BlueprintCallable, Category = "Lidar|Export")
+    static TArray<ALidarPointCloudActor*> GetVisibleLidarActors(
+        UCameraComponent* Camera,
+        float FrustumFar = 10000.f
     );
 };


### PR DESCRIPTION
## Summary
- add `GetVisibleLidarActors` to blueprint helper
- expose helper to Blueprint for finding LidarPointCloudActors inside a camera frustum

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686f5ea9cb9c83288b7c4fcf21b3c21b