### PR TITLE
Apply MaxPointCount limit during export

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Outputting LOD-Processed Point Clouds from a Camera Frustum
 ## Sample Scene
 1. Open the project and load `Content/LiDAR-Test/L_Test.umap`.
 2. The `BP_Test` blueprint calls `ExportVisiblePointsLOD` with an array of `LidarPointCloudActor` references and its `CameraComponent`. The visible portions of all clouds are merged and exported to `output.txt`.
-3. You can limit the number of exported points with the optional `MaxPointCount` parameter. The default is `20,000,000`.
+3. You can limit the number of exported points with the optional `MaxPointCount` parameter. The limit is applied after LOD processing and points beyond the limit are skipped to avoid long export times. The default is `20,000,000`.
 
 ## Example Output
 `docs/example_output.txt` shows a sample of the exported data. Each line follows the format `X Y Z Intensity R G B` where `Intensity` is measured in meters.

--- a/Source/PointCloudExport/ExportVisibleLidarPointsLOD.cpp
+++ b/Source/PointCloudExport/ExportVisibleLidarPointsLOD.cpp
@@ -160,15 +160,9 @@ bool UExportVisibleLidarPointsLOD::ExportVisiblePointsLOD(
     ULidarPointCloud* FirstCloud = nullptr;
 
     const bool bUseLimit = MaxPointCount > 0;
-    bool bReachedLimit = false;
 
     for (ALidarPointCloudActor* Actor : PointCloudActors)
     {
-        if (bUseLimit && AllPoints.Num() >= MaxPointCount)
-        {
-            bReachedLimit = true;
-            break;
-        }
         if (!Actor) continue;
         ULidarPointCloudComponent* Comp = Actor->GetPointCloudComponent();
         ULidarPointCloud* Cloud = Comp ? Comp->GetPointCloud() : nullptr;
@@ -193,21 +187,12 @@ bool UExportVisibleLidarPointsLOD::ExportVisiblePointsLOD(
         const FTransform& CloudToWorld = Comp->GetComponentTransform();
         for (const auto* P : VisiblePts)
         {
-            if (bUseLimit && AllPoints.Num() >= MaxPointCount)
-            {
-                bReachedLimit = true;
-                break;
-            }
             FPointRec Rec;
             Rec.WorldPos = CloudToWorld.TransformPosition(FVector(P->Location) + LocationOffset);
             Rec.LocalPos = FVector(P->Location) + LocationOffset;
             Rec.Color = P->Color;
             Rec.SourceCloud = Cloud;
             AllPoints.Add(Rec);
-        }
-        if (bReachedLimit)
-        {
-            break;
         }
     }
 
@@ -222,54 +207,62 @@ bool UExportVisibleLidarPointsLOD::ExportVisiblePointsLOD(
 
     const FVector CamLoc = Camera->GetComponentLocation();
 
+    const int32 ReserveCount = bUseLimit
+        ? FMath::Min<int32>(PointsToProcess.Num(), MaxPointCount)
+        : PointsToProcess.Num();
     TArray<FString> Lines;
-    Lines.SetNum(PointsToProcess.Num());
+    Lines.Reserve(ReserveCount);
 #if WITH_EDITOR
     TArray<FLinearColor> PosBuffer;
     TArray<FColor> ColorBuffer;
     if (bExportTexture)
     {
-        PosBuffer.SetNum(PointsToProcess.Num());
-        ColorBuffer.SetNum(PointsToProcess.Num());
+        PosBuffer.Reserve(ReserveCount);
+        ColorBuffer.Reserve(ReserveCount);
     }
 #endif
 
-    ParallelFor(PointsToProcess.Num(), [&](int32 Index)
+    for (int32 Index = 0; Index < PointsToProcess.Num(); ++Index)
+    {
+        const FPointRec& Rec = PointsToProcess[Index];
+        float Dist = FVector::Dist(Rec.WorldPos, CamLoc);
+        float Skip = 1.0f;
+
+        if (Dist > FarSkipRadius) {
+            Skip = (float)SkipFactorFar;
+        }
+        else if (Dist > MidSkipRadius) {
+            float t = (Dist - MidSkipRadius) / (FarSkipRadius - MidSkipRadius);
+            Skip = FMath::Lerp((float)SkipFactorMid, (float)SkipFactorFar, t);
+        }
+        else if (Dist > NearFullResRadius) {
+            float t = (Dist - NearFullResRadius) / (MidSkipRadius - NearFullResRadius);
+            Skip = FMath::Lerp(1.0f, (float)SkipFactorMid, t);
+        }
+
+        if (FMath::Fmod((float)(Index + 1), Skip) >= 1.0f)
         {
-            const FPointRec& Rec = PointsToProcess[Index];
-            float Dist = FVector::Dist(Rec.WorldPos, CamLoc);
-            float Skip = 1.0f;
+            continue;
+        }
 
-            if (Dist > FarSkipRadius) {
-                Skip = (float)SkipFactorFar;
-            }
-            else if (Dist > MidSkipRadius) {
-                float t = (Dist - MidSkipRadius) / (FarSkipRadius - MidSkipRadius);
-                Skip = FMath::Lerp((float)SkipFactorMid, (float)SkipFactorFar, t);
-            }
-            else if (Dist > NearFullResRadius) {
-                float t = (Dist - NearFullResRadius) / (MidSkipRadius - NearFullResRadius);
-                Skip = FMath::Lerp(1.0f, (float)SkipFactorMid, t);
-            }
-
-            if (FMath::Fmod((float)(Index + 1), Skip) >= 1.0f)
-            {
-                return;
-            }
-
-            const FVector UsePos = (bWorldSpace ? Rec.WorldPos : Rec.LocalPos);
-            Lines[Index] = FString::Printf(TEXT("%.8f %.8f %.8f %d %d %d %d"),
-                UsePos.X * 0.01f, -UsePos.Y * 0.01f, UsePos.Z * 0.01f,
-                Rec.Color.A, Rec.Color.R, Rec.Color.G, Rec.Color.B);
+        const FVector UsePos = (bWorldSpace ? Rec.WorldPos : Rec.LocalPos);
+        Lines.Add(FString::Printf(TEXT("%.8f %.8f %.8f %d %d %d %d"),
+            UsePos.X * 0.01f, -UsePos.Y * 0.01f, UsePos.Z * 0.01f,
+            Rec.Color.A, Rec.Color.R, Rec.Color.G, Rec.Color.B));
 #if WITH_EDITOR
-            if (bExportTexture)
-            {
-                PosBuffer[Index] = FLinearColor(UsePos.X, UsePos.Y, UsePos.Z, 1.f);
-                // Preserve the original alpha channel which stores point intensity
-                ColorBuffer[Index] = FColor(Rec.Color.R, Rec.Color.G, Rec.Color.B, Rec.Color.A);
-            }
+        if (bExportTexture)
+        {
+            PosBuffer.Add(FLinearColor(UsePos.X, UsePos.Y, UsePos.Z, 1.f));
+            // Preserve the original alpha channel which stores point intensity
+            ColorBuffer.Add(FColor(Rec.Color.R, Rec.Color.G, Rec.Color.B, Rec.Color.A));
+        }
 #endif
-        });
+
+        if (bUseLimit && Lines.Num() >= MaxPointCount)
+        {
+            break;
+        }
+    }
 
     TArray<FString> FinalLines;
     FinalLines.Reserve(PointsToProcess.Num());
@@ -306,6 +299,18 @@ bool UExportVisibleLidarPointsLOD::ExportVisiblePointsLOD(
         ColorBuffer = MoveTemp(FinalColor);
     }
 #endif
+
+    if (bUseLimit && Lines.Num() > MaxPointCount)
+    {
+        Lines.SetNum(MaxPointCount);
+#if WITH_EDITOR
+        if (bExportTexture)
+        {
+            PosBuffer.SetNum(MaxPointCount);
+            ColorBuffer.SetNum(MaxPointCount);
+        }
+#endif
+    }
 
     if (Lines.Num() == 0)
     {

--- a/Source/PointCloudExport/ExportVisibleLidarPointsLOD.h
+++ b/Source/PointCloudExport/ExportVisibleLidarPointsLOD.h
@@ -34,7 +34,7 @@ public:
      * @param SkipFactorFar       最遠距離帯でのサンプリング間隔
      * @param bWorldSpace         true: ワールド座標 / false: 点群ローカル
      * @param bExportTexture      位置/色テクスチャを UAsset として保存
-     * @param MaxPointCount       出力するポイント数の上限 (0 以下で無制限)
+     * @param MaxPointCount       LOD 適用後に出力するポイント数の上限。上限に達すると以降のポイントは処理をスキップする (0 以下で無制限)
      * @return                    成功可否
      */
     UFUNCTION(BlueprintCallable, Category = "Lidar|Export")


### PR DESCRIPTION
## Summary
- clarify in README that points beyond `MaxPointCount` are skipped
- note the skip behavior in `ExportVisibleLidarPointsLOD` API comment
- stop processing once the `MaxPointCount` limit is reached

## Testing
- `clang++ --version | head -n 1`


------
https://chatgpt.com/codex/tasks/task_b_687144d3291083288716b7f8147b5aaf