### PR TITLE
Create output directory automatically before exporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Outputting LOD-Processed Point Clouds from a Camera Frustum
 
 ## Sample Scene
 1. Open the project and load `Content/LiDAR-Test/L_Test.umap`.
-2. The `BP_Test` blueprint calls `ExportVisiblePointsLOD` with an array of `LidarPointCloudActor` references and its `CameraComponent`. The visible portions of all clouds are merged and exported to `output.txt`.
+2. The `BP_Test` blueprint calls `ExportVisiblePointsLOD` with an array of `LidarPointCloudActor` references and its `CameraComponent`. The visible portions of all clouds are merged and exported to `output.txt`. The output directory is created automatically if it does not already exist.
 3. You can limit the number of exported points with the optional `MaxPointCount` parameter. The limit is applied after LOD processing and points beyond the limit are skipped to avoid long export times. The default is `20,000,000`.
 
 ## Example Output

--- a/Source/PointCloudExport/ExportVisibleLidarPointsLOD.cpp
+++ b/Source/PointCloudExport/ExportVisibleLidarPointsLOD.cpp
@@ -9,6 +9,7 @@
 #include "Math/Plane.h"
 #include "HAL/FileManager.h"
 #include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
 #include "EngineUtils.h"
 #include "Async/Async.h"
 #if WITH_EDITOR
@@ -291,6 +292,17 @@ bool UExportVisibleLidarPointsLOD::ExportVisiblePointsLOD(
     {
         UE_LOG(LogTemp, Warning, TEXT("ExportVisiblePointsLOD: All points skipped by LOD."));
         return false;
+    }
+
+    const FString DirectoryPath = FPaths::GetPath(AbsoluteFilePath);
+    if (!DirectoryPath.IsEmpty() && !IFileManager::Get().DirectoryExists(*DirectoryPath))
+    {
+        if (!IFileManager::Get().MakeDirectory(*DirectoryPath, true))
+        {
+            UE_LOG(LogTemp, Error,
+                TEXT("ExportVisiblePointsLOD: Failed to create directory %s"), *DirectoryPath);
+            return false;
+        }
     }
 
     const FString Joined = FString::Join(Lines, TEXT("\n")) + TEXT("\n");


### PR DESCRIPTION
## Summary
- check directory path before saving file and create it as needed
- include `Misc/Paths.h`
- update README about automatic directory creation

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_687270f259448328a620ef7c53a85171