### PR TITLE
Improve MaxPointCount logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Outputting LOD-Processed Point Clouds from a Camera Frustum
 ## Sample Scene
 1. Open the project and load `Content/LiDAR-Test/L_Test.umap`.
 2. The `BP_Test` blueprint calls `ExportVisiblePointsLOD` with an array of `LidarPointCloudActor` references and its `CameraComponent`. The visible portions of all clouds are merged and exported to `output.txt`. The output directory is created automatically if it does not already exist.
-3. You can limit the number of exported points with the optional `MaxPointCount` parameter. If the LOD-processed point count exceeds this limit, the points are sorted by distance from the camera and the closest points are kept. When the count does not exceed the limit, no sorting is performed. The default is `20,000,000`.
+3. You can limit the number of exported points with the optional `MaxPointCount` parameter. If the LOD-processed point count exceeds this limit, the points are sorted by distance from the camera using a parallel bitonic sort and only the closest points are kept. When the count does not exceed the limit, no sorting is performed. The default is `20,000,000`.
 
 ## Example Output
 `docs/example_output.txt` shows a sample of the exported data. Each line follows the format `X Y Z Intensity R G B` where `Intensity` is measured in meters.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Outputting LOD-Processed Point Clouds from a Camera Frustum
 ## Sample Scene
 1. Open the project and load `Content/LiDAR-Test/L_Test.umap`.
 2. The `BP_Test` blueprint calls `ExportVisiblePointsLOD` with an array of `LidarPointCloudActor` references and its `CameraComponent`. The visible portions of all clouds are merged and exported to `output.txt`. The output directory is created automatically if it does not already exist.
-3. You can limit the number of exported points with the optional `MaxPointCount` parameter. The limit is applied after LOD processing and points beyond the limit are skipped to avoid long export times. The default is `20,000,000`.
+3. You can limit the number of exported points with the optional `MaxPointCount` parameter. If the LOD-processed point count exceeds this limit, the points are sorted by distance from the camera and the closest points are kept. When the count does not exceed the limit, no sorting is performed. The default is `20,000,000`.
 
 ## Example Output
 `docs/example_output.txt` shows a sample of the exported data. Each line follows the format `X Y Z Intensity R G B` where `Intensity` is measured in meters.

--- a/Source/PointCloudExport/ExportVisibleLidarPointsLOD.cpp
+++ b/Source/PointCloudExport/ExportVisibleLidarPointsLOD.cpp
@@ -12,8 +12,8 @@
 #include "Misc/Paths.h"
 #include "EngineUtils.h"
 #include "Async/Async.h"
-#include "Algo/Sort.h"
-#include "Algo/ParallelSort.h"
+#include "Async/ParallelFor.h"
+#include <cfloat>
 #if WITH_EDITOR
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "UObject/Package.h"
@@ -84,6 +84,60 @@ static void BuildFrustumFromCamera(const UCameraComponent* Camera, FConvexVolume
     OutFrustum.Init();
 }
 
+struct FPointRec
+{
+    FVector WorldPos;
+    FVector LocalPos;
+    float   Distance = 0.f;
+    FColor  Color;
+};
+
+template <typename Predicate>
+static void ParallelBitonicSort(TArray<FPointRec>& Array, Predicate Pred)
+{
+    const int32 N = Array.Num();
+    int32 Pow2 = 1;
+    while (Pow2 < N)
+    {
+        Pow2 <<= 1;
+    }
+
+    if (Pow2 > N)
+    {
+        FPointRec Sentinel;
+        Sentinel.Distance = FLT_MAX;
+        Array.AddDefaulted(Pow2 - N);
+        for (int32 i = N; i < Pow2; ++i)
+        {
+            Array[i] = Sentinel;
+        }
+    }
+
+    for (int32 k = 2; k <= Pow2; k <<= 1)
+    {
+        for (int32 j = k >> 1; j > 0; j >>= 1)
+        {
+            ParallelFor(Pow2, [&](int32 i)
+            {
+                int32 ixj = i ^ j;
+                if (ixj > i)
+                {
+                    const bool Asc = (i & k) == 0;
+                    const bool SwapNeeded = Asc ? Pred(Array[ixj], Array[i]) : Pred(Array[i], Array[ixj]);
+                    if (SwapNeeded)
+                    {
+                        Swap(Array[i], Array[ixj]);
+                    }
+                }
+            });
+        }
+    }
+
+    if (Pow2 > N)
+    {
+        Array.SetNum(N);
+    }
+}
 
 
 // ------------------------------------------------------------
@@ -138,16 +192,6 @@ bool UExportVisibleLidarPointsLOD::ExportVisiblePointsLOD(
     // 1) 視錐台フィルタリング
     FConvexVolume WorldFrustum;
     BuildFrustumFromCamera(Camera, WorldFrustum, FrustumFar);
-
-    struct FPointRec
-    {
-        FVector WorldPos;
-        FVector LocalPos;
-        // Distance from camera for sorting
-        float    Distance = 0.f;
-        // Color.A stores the intensity value from the source point cloud
-        FColor   Color;
-    };
 
     TArray<FPointRec> AllPoints;
     ULidarPointCloud* FirstCloud = nullptr;
@@ -244,7 +288,7 @@ bool UExportVisibleLidarPointsLOD::ExportVisiblePointsLOD(
 
     if (bUseLimit && AllPoints.Num() > MaxPointCount)
     {
-        Algo::ParallelSort(AllPoints, [](const FPointRec& A, const FPointRec& B)
+        ParallelBitonicSort(AllPoints, [](const FPointRec& A, const FPointRec& B)
         {
             return A.Distance < B.Distance;
         });

--- a/Source/PointCloudExport/ExportVisibleLidarPointsLOD.cpp
+++ b/Source/PointCloudExport/ExportVisibleLidarPointsLOD.cpp
@@ -12,6 +12,8 @@
 #include "Misc/Paths.h"
 #include "EngineUtils.h"
 #include "Async/Async.h"
+#include "Algo/Sort.h"
+#include "Algo/ParallelSort.h"
 #if WITH_EDITOR
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "UObject/Package.h"
@@ -141,6 +143,8 @@ bool UExportVisibleLidarPointsLOD::ExportVisiblePointsLOD(
     {
         FVector WorldPos;
         FVector LocalPos;
+        // Distance from camera for sorting
+        float    Distance = 0.f;
         // Color.A stores the intensity value from the source point cloud
         FColor   Color;
     };
@@ -211,6 +215,7 @@ bool UExportVisibleLidarPointsLOD::ExportVisiblePointsLOD(
                 FPointRec Rec;
                 Rec.WorldPos = WorldPos;
                 Rec.LocalPos = FVector(P->Location) + LocationOffset;
+                Rec.Distance = Dist;
                 Rec.Color = P->Color;
                 LocalPoints.Add(Rec);
             }
@@ -237,9 +242,16 @@ bool UExportVisibleLidarPointsLOD::ExportVisiblePointsLOD(
         return false;
     }
 
-    const int32 ReserveCount = bUseLimit
-        ? FMath::Min<int32>(AllPoints.Num(), MaxPointCount)
-        : AllPoints.Num();
+    if (bUseLimit && AllPoints.Num() > MaxPointCount)
+    {
+        Algo::ParallelSort(AllPoints, [](const FPointRec& A, const FPointRec& B)
+        {
+            return A.Distance < B.Distance;
+        });
+        AllPoints.SetNum(MaxPointCount);
+    }
+
+    const int32 ReserveCount = AllPoints.Num();
     TArray<FString> Lines;
     Lines.Reserve(ReserveCount);
 #if WITH_EDITOR
@@ -269,23 +281,6 @@ bool UExportVisibleLidarPointsLOD::ExportVisiblePointsLOD(
         }
 #endif
 
-        if (bUseLimit && Lines.Num() >= MaxPointCount)
-        {
-            break;
-        }
-    }
-
-
-    if (bUseLimit && Lines.Num() > MaxPointCount)
-    {
-        Lines.SetNum(MaxPointCount);
-#if WITH_EDITOR
-        if (bExportTexture)
-        {
-            PosBuffer.SetNum(MaxPointCount);
-            ColorBuffer.SetNum(MaxPointCount);
-        }
-#endif
     }
 
     if (Lines.Num() == 0)

--- a/Source/PointCloudExport/ExportVisibleLidarPointsLOD.h
+++ b/Source/PointCloudExport/ExportVisibleLidarPointsLOD.h
@@ -33,7 +33,7 @@ public:
      * @param SkipFactorFar       最遠距離帯でのサンプリング間隔
      * @param bWorldSpace         true: ワールド座標 / false: 点群ローカル
      * @param bExportTexture      位置/色テクスチャを UAsset として保存
-     * @param MaxPointCount       LOD 適用後に出力するポイント数の上限。上限に達すると以降のポイントは処理をスキップする (0 以下で無制限)
+     * @param MaxPointCount       LOD 適用後に出力するポイント数の上限。上限を超えた場合、カメラからの距離で並び替えて近い順にこの数だけを保持する (0 以下で無制限)
      * @return                    成功可否
      */
     UFUNCTION(BlueprintCallable, Category = "Lidar|Export")

--- a/Source/PointCloudExport/ExportVisibleLidarPointsLOD.h
+++ b/Source/PointCloudExport/ExportVisibleLidarPointsLOD.h
@@ -33,7 +33,7 @@ public:
      * @param SkipFactorFar       最遠距離帯でのサンプリング間隔
      * @param bWorldSpace         true: ワールド座標 / false: 点群ローカル
      * @param bExportTexture      位置/色テクスチャを UAsset として保存
-     * @param MaxPointCount       LOD 適用後に出力するポイント数の上限。上限を超えた場合、カメラからの距離で並び替えて近い順にこの数だけを保持する (0 以下で無制限)
+     * @param MaxPointCount       LOD 適用後に出力するポイント数の上限。上限を超えた場合、カメラからの距離で並び替えて近い順にこの数だけを保持する。並び替えは並列バイトニックソートで実行される (0 以下で無制限)
      * @return                    成功可否
      */
     UFUNCTION(BlueprintCallable, Category = "Lidar|Export")


### PR DESCRIPTION
## Summary
- store camera distance in `FPointRec`
- sort points by camera distance when exceeding `MaxPointCount`
- keep only the closest points
- update README and API comment about the new behavior

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68727747f7008328937ad3b2da0fc34e