### PR TITLE
Add point cloud render target writer component

### DIFF
--- a/Source/PointCloudExport/PointCloudExport.Build.cs
+++ b/Source/PointCloudExport/PointCloudExport.Build.cs
@@ -10,7 +10,7 @@ public class PointCloudExport : ModuleRules
 	
 		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput", "AssetRegistry" });
 
-                PrivateDependencyModuleNames.AddRange(new string[] { "LidarPointCloudRuntime" });
+                PrivateDependencyModuleNames.AddRange(new string[] { "LidarPointCloudRuntime", "RenderCore", "RHI" });
 
                 if (Target.bBuildEditor)
                 {

--- a/Source/PointCloudExport/PointCloudRTWriterComponent.cpp
+++ b/Source/PointCloudExport/PointCloudRTWriterComponent.cpp
@@ -1,0 +1,84 @@
+#include "PointCloudRTWriterComponent.h"
+
+#include "LidarPointCloudActor.h"
+#include "LidarPointCloudComponent.h"
+#include "LidarPointCloud.h"
+#include "Engine/TextureRenderTarget2D.h"
+#include "RenderUtils.h"
+#include "RHICommandList.h"
+
+UPointCloudRTWriterComponent::UPointCloudRTWriterComponent()
+{
+    PrimaryComponentTick.bCanEverTick = true;
+}
+
+void UPointCloudRTWriterComponent::BeginPlay()
+{
+    Super::BeginPlay();
+}
+
+void UPointCloudRTWriterComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
+{
+    Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+
+    ALidarPointCloudActor* OwnerActor = Cast<ALidarPointCloudActor>(GetOwner());
+    if (!OwnerActor || !PositionRenderTarget || !ColorRenderTarget)
+    {
+        return;
+    }
+
+    ULidarPointCloudComponent* Comp = OwnerActor->GetPointCloudComponent();
+    ULidarPointCloud* Cloud = Comp ? Comp->GetPointCloud() : nullptr;
+    if (!Cloud)
+    {
+        return;
+    }
+
+    TArray64<FLidarPointCloudPoint*> Points;
+    Cloud->GetPoints(Points);
+    const int32 PointCount = Points.Num();
+    if (PointCount == 0)
+    {
+        return;
+    }
+
+    const int32 TexDim = FMath::CeilToInt(FMath::Sqrt(static_cast<float>(PointCount)));
+    if (PositionRenderTarget->SizeX != TexDim || PositionRenderTarget->SizeY != TexDim)
+    {
+        PositionRenderTarget->ResizeTarget(TexDim, TexDim);
+    }
+    if (ColorRenderTarget->SizeX != TexDim || ColorRenderTarget->SizeY != TexDim)
+    {
+        ColorRenderTarget->ResizeTarget(TexDim, TexDim);
+    }
+
+    TArray<FFloat16Color> PosPixels;
+    TArray<FColor> ColorPixels;
+    PosPixels.Init(FFloat16Color(FLinearColor::Transparent), TexDim * TexDim);
+    ColorPixels.Init(FColor(0, 0, 0, 0), TexDim * TexDim);
+
+    for (int32 i = 0; i < PointCount; ++i)
+    {
+        const FLidarPointCloudPoint* P = Points[i];
+        const FVector Pos = FVector(P->Location);
+        PosPixels[i] = FFloat16Color(FLinearColor(Pos.X, Pos.Y, Pos.Z, 1.f));
+        ColorPixels[i] = FColor(P->Color.R, P->Color.G, P->Color.B, P->Color.A);
+    }
+
+    FTextureRenderTargetResource* PosResource = PositionRenderTarget->GameThread_GetRenderTargetResource();
+    FTextureRenderTargetResource* ColorResource = ColorRenderTarget->GameThread_GetRenderTargetResource();
+
+    TArray<FFloat16Color> PosData = PosPixels;
+    TArray<FColor> ColorData = ColorPixels;
+
+    ENQUEUE_RENDER_COMMAND(UpdatePointCloudRT)(
+        [PosResource, ColorResource, PosData, ColorData, TexDim](FRHICommandListImmediate& RHICmdList)
+        {
+            FUpdateTextureRegion2D Region(0, 0, 0, 0, TexDim, TexDim);
+            const uint32 PosPitch = TexDim * sizeof(FFloat16Color);
+            RHICmdList.UpdateTexture2D(PosResource->GetTexture2DRHI(), 0, Region, PosPitch, (uint8*)PosData.GetData());
+            const uint32 ColorPitch = TexDim * sizeof(FColor);
+            RHICmdList.UpdateTexture2D(ColorResource->GetTexture2DRHI(), 0, Region, ColorPitch, (uint8*)ColorData.GetData());
+        });
+}
+

--- a/Source/PointCloudExport/PointCloudRTWriterComponent.h
+++ b/Source/PointCloudExport/PointCloudRTWriterComponent.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "PointCloudRTWriterComponent.generated.h"
+
+class UTextureRenderTarget2D;
+
+/**
+ * Component that writes point cloud positions and colors to render targets each tick.
+ * Attach to a LidarPointCloudActor and assign render targets for positions and colors.
+ */
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class POINTCLOUDEXPORT_API UPointCloudRTWriterComponent : public UActorComponent
+{
+    GENERATED_BODY()
+
+public:
+    UPointCloudRTWriterComponent();
+
+    virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+
+    /** Render target receiving XYZ positions encoded as float16 RGBA */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="PointCloud")
+    UTextureRenderTarget2D* PositionRenderTarget;
+
+    /** Render target receiving point colors */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="PointCloud")
+    UTextureRenderTarget2D* ColorRenderTarget;
+
+protected:
+    virtual void BeginPlay() override;
+};
+


### PR DESCRIPTION
## Summary
- expose PointCloudRTWriterComponent to stream Lidar point cloud positions and colors into render targets
- add RenderCore and RHI dependencies for new component

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689b1f9afaec83289e1ba2120736cab7